### PR TITLE
Add HTTP status code validation in helpers.go

### DIFF
--- a/internal/keylime/helpers.go
+++ b/internal/keylime/helpers.go
@@ -7,8 +7,44 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"strings"
 )
+
+// ExtractAPIError reads a limited portion of the response body and returns a descriptive error.
+func ExtractAPIError(resp *http.Response) error {
+	const maxErrorBody = 16 * 1024 // 16KB limit to prevent OOM on large error payloads
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	var apiErr struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(bodyBytes, &apiErr); err == nil && apiErr.Status != "" {
+		return fmt.Errorf("API error (HTTP %d): %s", resp.StatusCode, apiErr.Status)
+	}
+	return fmt.Errorf("API request failed with HTTP %d: %s", resp.StatusCode, sanitizeErrorBody(bodyBytes))
+}
+
+// sanitizeErrorBody truncates and strips non-printable characters from raw
+// response bodies so that error messages remain readable and bounded.
+func sanitizeErrorBody(body []byte) string {
+	const maxPreview = 512
+	truncated := false
+	if len(body) > maxPreview {
+		body = body[:maxPreview]
+		truncated = true
+	}
+	clean := make([]byte, 0, len(body))
+	for _, b := range body {
+		if b >= 0x20 && b < 0x7f || b == '\n' || b == '\t' {
+			clean = append(clean, b)
+		}
+	}
+	s := string(clean)
+	if truncated {
+		s += "... (truncated)"
+	}
+	return s
+}
 
 // Service handles Keylime operations with verifier and registrar clients
 type Service struct {
@@ -48,6 +84,10 @@ func (s *Service) FetchAllAgentUUIDs(ctx context.Context) ([]string, error) {
 		_ = resp.Body.Close()
 	}()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ExtractAPIError(resp)
+	}
+
 	var agents AgentListResponse
 	err = json.NewDecoder(resp.Body).Decode(&agents)
 	if err != nil {
@@ -73,6 +113,10 @@ func (s *Service) PrepareEnrollmentBody(ctx context.Context, agentUUID, runtimeP
 		_ = regResp.Body.Close()
 	}()
 
+	if regResp.StatusCode < 200 || regResp.StatusCode >= 300 {
+		return nil, fmt.Errorf("agent %s: %w", agentUUID, ExtractAPIError(regResp))
+	}
+
 	var regDetails RegistrarGetAgentDetailsOutput
 	if err := json.NewDecoder(regResp.Body).Decode(&regDetails); err != nil {
 		return nil, fmt.Errorf("failed to decode registrar response: %w", err)
@@ -88,6 +132,10 @@ func (s *Service) PrepareEnrollmentBody(ctx context.Context, agentUUID, runtimeP
 			_, _ = io.Copy(io.Discard, policyResp.Body)
 			_ = policyResp.Body.Close()
 		}()
+
+		if policyResp.StatusCode < 200 || policyResp.StatusCode >= 300 {
+			return nil, fmt.Errorf("runtime policy %q: %w", runtimePolicyName, ExtractAPIError(policyResp))
+		}
 
 		var policyData GetRuntimePolicyOutput
 		if err := json.NewDecoder(policyResp.Body).Decode(&policyData); err != nil {
@@ -142,6 +190,10 @@ func (s *Service) FetchAgentDetails(ctx context.Context, agentUUID string) (Agen
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return AgentStatusResponse{}, fmt.Errorf("agent %s: %w", agentUUID, ExtractAPIError(resp))
+	}
 
 	var agentStatus AgentStatusResponse
 	err = json.NewDecoder(resp.Body).Decode(&agentStatus)

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -55,7 +55,7 @@ func (h *ToolHandler) GetVerifierEnrolledAgents(ctx context.Context, req *mcp.Ca
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, extractAPIError(resp)
+		return nil, nil, keylime.ExtractAPIError(resp)
 	}
 
 	var parsed struct {
@@ -408,7 +408,7 @@ func (h *ToolHandler) ImportRuntimePolicy(ctx context.Context, req *mcp.CallTool
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, extractAPIError(resp)
+		return nil, nil, keylime.ExtractAPIError(resp)
 	}
 
 	return nil, keylime.ImportRuntimePolicyOutput{Name: input.Name, Status: "imported"}, nil
@@ -438,7 +438,7 @@ func (h *ToolHandler) UpdateRuntimePolicy(ctx context.Context, req *mcp.CallTool
 	}()
 
 	if getResp.StatusCode < 200 || getResp.StatusCode >= 300 {
-		return nil, nil, extractAPIError(getResp)
+		return nil, nil, keylime.ExtractAPIError(getResp)
 	}
 
 	var policyData keylime.GetRuntimePolicyOutput
@@ -540,7 +540,7 @@ func (h *ToolHandler) UpdateRuntimePolicy(ctx context.Context, req *mcp.CallTool
 	}()
 
 	if reuploadResp.StatusCode < 200 || reuploadResp.StatusCode >= 300 {
-		return nil, nil, extractAPIError(reuploadResp)
+		return nil, nil, keylime.ExtractAPIError(reuploadResp)
 	}
 
 	return nil, keylime.UpdateRuntimePolicyOutput{PolicyName: input.PolicyName, Status: "updated"}, nil
@@ -619,7 +619,7 @@ func (h *ToolHandler) ImportMBPolicy(ctx context.Context, req *mcp.CallToolReque
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, extractAPIError(resp)
+		return nil, nil, keylime.ExtractAPIError(resp)
 	}
 
 	return nil, keylime.ImportMBPolicyOutput{Name: input.Name, Status: "imported"}, nil

--- a/internal/mcptools/utils.go
+++ b/internal/mcptools/utils.go
@@ -14,19 +14,6 @@ import (
 	"github.com/keylime/keylime-mcp/internal/keylime"
 )
 
-// extractAPIError reads a limited portion of the response body and returns a descriptive error.
-func extractAPIError(resp *http.Response) error {
-	const maxErrorBody = 16 * 1024 // 16KB limit to prevent OOM on large error payloads
-	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
-	var apiErr struct {
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal(bodyBytes, &apiErr); err == nil && apiErr.Status != "" {
-		return fmt.Errorf("API error (HTTP %d): %s", resp.StatusCode, apiErr.Status)
-	}
-	return fmt.Errorf("API request failed with HTTP %d: %s", resp.StatusCode, string(bodyBytes))
-}
-
 // fetchAndDecode reads an HTTP response body and decodes it into a typed struct.
 // It drains any unread bytes before closing to ensure HTTP connection reuse.
 func fetchAndDecode[T any](resp *http.Response, err error) (T, error) {
@@ -39,7 +26,7 @@ func fetchAndDecode[T any](resp *http.Response, err error) (T, error) {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return zero, extractAPIError(resp)
+		return zero, keylime.ExtractAPIError(resp)
 	}
 	var result T
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
@@ -58,7 +45,7 @@ func deleteAndCheck(resp *http.Response, err error) error {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return extractAPIError(resp)
+		return keylime.ExtractAPIError(resp)
 	}
 	return nil
 }


### PR DESCRIPTION
Validate response status codes in FetchAllAgentUUIDs, PrepareEnrollmentBody (registrar and policy fetches), and FetchAgentDetails before attempting JSON decoding. Non-2xx responses now return descriptive errors with the HTTP status code and the relevant agent UUID or policy name, preventing error payloads from being silently decoded into zero-value structs.

Resolves: #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified HTTP error handling: non-2xx responses are detected earlier and now return clearer, contextual error messages (including a truncated response body or parsed status when available) instead of downstream decoding errors.
  * Consistent behavior applied across multiple tools and service calls, improving reliability and troubleshooting for failed external requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->