### PR TITLE
Add data masking for LLM-exposed values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,8 @@ KEYLIME_CERT_DIR=/var/lib/keylime/cv_ca
 # LLMs
 ANTHROPIC_API_KEY=...
 
+# Mask sensitive data before sending to LLM (default: true)
+MASKING_ENABLED=true
+
 # Server configuration
 PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "Setup:"
 	@echo "  make install      - Full setup (check deps, env, certs, build)"
 	@echo "  make check-deps   - Verify Go is installed and certs are readable"
-	@echo "  make setup-certs  - Grant read access to Keylime certs (requires sudo)"
+	@echo "  make setup-certs  - Grant permanent read access to Keylime certs (requires sudo)"
 	@echo ""
 	@echo "Build & Run:"
 	@echo "  make build-server - Build MCP server binary"
@@ -39,14 +39,15 @@ start:
 KEYLIME_CERT_DIR := /var/lib/keylime/cv_ca
 CERT_FILES := cacert.crt client-cert.crt client-private.pem
 
+TMPFILES_CONF := /etc/tmpfiles.d/keylime-mcp.conf
+
 setup-certs:
-	@echo "Granting read access to Keylime certificates for user '$(USER)'..."
-	@sudo setfacl -m u:$(USER):rx /var/lib/keylime
-	@sudo setfacl -m u:$(USER):rx $(KEYLIME_CERT_DIR)
-	@for f in $(CERT_FILES); do \
-		sudo setfacl -m u:$(USER):r "$(KEYLIME_CERT_DIR)/$$f"; \
-	done
-	@echo "Done. Certificate access granted."
+	@printf 'a+ %s - - - - u:$(USER):%s\n' \
+		/var/lib/keylime rx \
+		$(KEYLIME_CERT_DIR) rx \
+		$(foreach f,$(CERT_FILES),$(KEYLIME_CERT_DIR)/$(f) r) \
+		| sudo tee $(TMPFILES_CONF) > /dev/null
+	@sudo systemd-tmpfiles --create $(TMPFILES_CONF)
 
 check-deps:
 	@echo "Checking dependencies..."

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 	@echo "Setup:"
 	@echo "  make install      - Full setup (check deps, env, certs, build)"
 	@echo "  make check-deps   - Verify Go is installed and certs are readable"
-	@echo "  make setup-certs  - Grant permanent read access to Keylime certs (requires sudo)"
+	@echo "  make setup-certs  - Grant read access to Keylime certs (requires sudo)"
 	@echo ""
 	@echo "Build & Run:"
 	@echo "  make build-server - Build MCP server binary"
@@ -39,15 +39,14 @@ start:
 KEYLIME_CERT_DIR := /var/lib/keylime/cv_ca
 CERT_FILES := cacert.crt client-cert.crt client-private.pem
 
-TMPFILES_CONF := /etc/tmpfiles.d/keylime-mcp.conf
-
 setup-certs:
-	@printf 'a+ %s - - - - u:$(USER):%s\n' \
-		/var/lib/keylime rx \
-		$(KEYLIME_CERT_DIR) rx \
-		$(foreach f,$(CERT_FILES),$(KEYLIME_CERT_DIR)/$(f) r) \
-		| sudo tee $(TMPFILES_CONF) > /dev/null
-	@sudo systemd-tmpfiles --create $(TMPFILES_CONF)
+	@echo "Granting read access to Keylime certificates for user '$(USER)'..."
+	@sudo setfacl -m u:$(USER):rx /var/lib/keylime
+	@sudo setfacl -m u:$(USER):rx $(KEYLIME_CERT_DIR)
+	@for f in $(CERT_FILES); do \
+		sudo setfacl -m u:$(USER):r "$(KEYLIME_CERT_DIR)/$$f"; \
+	done
+	@echo "Done. Certificate access granted."
 
 check-deps:
 	@echo "Checking dependencies..."

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/keylime/keylime-mcp/internal/agent"
+	"github.com/keylime/keylime-mcp/internal/masking"
 	"github.com/keylime/keylime-mcp/internal/web"
 )
 
@@ -63,7 +64,10 @@ func main() {
 		}
 	}
 
-	agentInstance := agent.NewAgent(cfg, initialProvider)
+	maskingEnabled := os.Getenv("MASKING_ENABLED") != "false"
+	masker := masking.NewEngine(maskingEnabled)
+
+	agentInstance := agent.NewAgent(cfg, initialProvider, masker)
 
 	if err := agentInstance.Connect(ctx); err != nil {
 		log.Printf("Failed to connect to MCP server: %v", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/keylime/keylime-mcp/internal/keylime"
+	"github.com/keylime/keylime-mcp/internal/masking"
 	"github.com/keylime/keylime-mcp/internal/mcptools"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -23,31 +24,32 @@ func main() {
 		log.Fatalf("Failed to initialize Keylime service: %v", err)
 	}
 	toolHandler := mcptools.NewToolHandler(keylimeService)
+	mask := masking.NewEngine(config.MaskingEnabled)
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "Keylime", Version: "v1.0.0"}, nil)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_version_and_health", Description: "Retrieves current and supported API Keylime Verifier and Registrar versions and checks if the services are reachable"}, toolHandler.GetVersionAndHealth)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_all_agents", Description: "Retrieves a list of all registered agent UUIDs from the registrar"}, toolHandler.GetAllAgents)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_verifier_enrolled_agents", Description: "Retrieves a list of agent UUIDs enrolled in the verifier for active attestation"}, toolHandler.GetVerifierEnrolledAgents)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_agent_status", Description: "Retrieves attestation status from the verifier: operational state, attestation count, severity, last quote timestamps, and algorithms."}, toolHandler.GetAgentStatus)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_failed_agents", Description: "Retrieves all agents currently in a failed operational state with their detailed status information including attestation history and failure reasons"}, toolHandler.GetFailedAgents)
-	mcp.AddTool(server, &mcp.Tool{Name: "Reactivate_agent", Description: "Reactivates a failed agent identified by its UUID"}, toolHandler.ReactivateAgent)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_agent_policies", Description: "Retrieves policy configuration (TPM, vTPM, runtime policies) for a specific agent"}, toolHandler.GetAgentPolicies)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_agent_details", Description: "Retrieves hardware identity from the registrar: EK certificate, AIK, mTLS cert, IP and port. Not attestation status — use Get_agent_status for that."}, toolHandler.RegistrarGetAgentDetails)
-	mcp.AddTool(server, &mcp.Tool{Name: "Registrar_remove_agent", Description: "Removes an agent from the registrar (NOT the verifier)"}, toolHandler.RegistrarRemoveAgent)
-	mcp.AddTool(server, &mcp.Tool{Name: "Enroll_agent_to_verifier", Description: "Enrolls a registered agent into the verifier for active attestation. Optional runtime_policy_name (use List_runtime_policies for names) and mb_policy_name (use List_mb_policies for names) refer to existing policies on the verifier. Leave empty to enroll without policy."}, toolHandler.EnrollAgentToVerifier)
-	mcp.AddTool(server, &mcp.Tool{Name: "Update_agent", Description: "Re-enrolls an agent with a new policy. Safely validates everything before unenrolling, then re-enrolls. Use this instead of manually calling Unenroll + Enroll."}, toolHandler.UpdateAgent)
-	mcp.AddTool(server, &mcp.Tool{Name: "Unenroll_agent_from_verifier", Description: "Unenrolls an agent from the verifier (NOT the registrar)"}, toolHandler.UnenrollAgentFromVerifier)
-	mcp.AddTool(server, &mcp.Tool{Name: "Stop_agent", Description: "Stop Verifier polling on an agent identified by its UUID, but does not remove the agent"}, toolHandler.StopAgent)
-	mcp.AddTool(server, &mcp.Tool{Name: "List_runtime_policies", Description: "Lists names of runtime policies already uploaded to the verifier. These are policies available for assigning to agents during enrollment."}, toolHandler.ListRuntimePolicies)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_runtime_policy", Description: "Gets the content of a specific runtime policy stored on the verifier by name. Returns the policy JSON including digests, excludes, and keyrings. Use List_runtime_policies first to see available names."}, toolHandler.GetRuntimePolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "Import_runtime_policy", Description: "Uploads a local runtime policy JSON file to the verifier. If the user has no policy file, ask whether they want to generate it from a local filesystem or a remote RPM repo. For local: 'sudo keylime-policy create runtime --rootfs / -o /tmp/runtime_policy.json'. For RPM repo: 'sudo keylime-policy create runtime --remote-rpm-repo <URL> -o /tmp/runtime_policy.json'. Then provide the output path to this tool."}, toolHandler.ImportRuntimePolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "Update_runtime_policy", Description: "Updates an existing runtime policy on the verifier. Can add or remove excludes and digests. Fetches the current policy, applies changes, and re-uploads. Requires at least one of add_excludes, remove_excludes, add_digests, or remove_digests."}, toolHandler.UpdateRuntimePolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "Delete_runtime_policy", Description: "Deletes a runtime policy from the verifier by name. Use List_runtime_policies first to see available names."}, toolHandler.DeleteRuntimePolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "List_mb_policies", Description: "Lists names of measured boot policies already uploaded to the verifier. These are policies available for assigning to agents during enrollment."}, toolHandler.ListMBPolicies)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_mb_policy", Description: "Gets the content of a specific measured boot policy stored on the verifier by name. Returns the policy JSON including boot event logs and expected PCR values. Use List_mb_policies first to see available names."}, toolHandler.GetMBPolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "Import_mb_policy", Description: "Uploads a local measured boot policy JSON file to the verifier. If the user has no policy file, tell them to generate one with: 'sudo keylime-policy create measured-boot -e /sys/kernel/security/tpm0/binary_bios_measurements -o /tmp/mb_policy.json'. If it fails with a SecureBoot error, add the -i flag to generate without SecureBoot validation. Then provide the output path to this tool."}, toolHandler.ImportMBPolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "Delete_mb_policy", Description: "Deletes a measured boot policy from the verifier by name. Use List_mb_policies first to see available names."}, toolHandler.DeleteMBPolicy)
-	mcp.AddTool(server, &mcp.Tool{Name: "Get_verifier_logs", Description: "Investigates attestation failures and retrieves Keylime Verifier logs from journalctl. Requires co-located verifier. Filter by agent_uuid and use filter parameter: 'attestation_failures' for file mismatches, invalid quotes and policy violations, 'errors' for error-level messages, 'all' for unfiltered output (default). Lines parameter controls log window (default 50, max 200)."}, toolHandler.InvestigateVerifierLogs)
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_version_and_health", Description: "Retrieves current and supported API Keylime Verifier and Registrar versions and checks if the services are reachable"}, masking.WrapTool(mask, toolHandler.GetVersionAndHealth))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_all_agents", Description: "Retrieves a list of all registered agent UUIDs from the registrar"}, masking.WrapTool(mask, toolHandler.GetAllAgents))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_verifier_enrolled_agents", Description: "Retrieves a list of agent UUIDs enrolled in the verifier for active attestation"}, masking.WrapTool(mask, toolHandler.GetVerifierEnrolledAgents))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_agent_status", Description: "Retrieves attestation status from the verifier: operational state, attestation count, severity, last quote timestamps, and algorithms."}, masking.WrapTool(mask, toolHandler.GetAgentStatus))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_failed_agents", Description: "Retrieves all agents currently in a failed operational state with their detailed status information including attestation history and failure reasons"}, masking.WrapTool(mask, toolHandler.GetFailedAgents))
+	mcp.AddTool(server, &mcp.Tool{Name: "Reactivate_agent", Description: "Reactivates a failed agent identified by its UUID"}, masking.WrapTool(mask, toolHandler.ReactivateAgent))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_agent_policies", Description: "Retrieves policy configuration (TPM, vTPM, runtime policies) for a specific agent"}, masking.WrapTool(mask, toolHandler.GetAgentPolicies))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_agent_details", Description: "Retrieves hardware identity from the registrar: EK certificate, AIK, mTLS cert, IP and port. Not attestation status — use Get_agent_status for that."}, masking.WrapTool(mask, toolHandler.RegistrarGetAgentDetails))
+	mcp.AddTool(server, &mcp.Tool{Name: "Registrar_remove_agent", Description: "Removes an agent from the registrar (NOT the verifier)"}, masking.WrapTool(mask, toolHandler.RegistrarRemoveAgent))
+	mcp.AddTool(server, &mcp.Tool{Name: "Enroll_agent_to_verifier", Description: "Enrolls a registered agent into the verifier for active attestation. Optional runtime_policy_name (use List_runtime_policies for names) and mb_policy_name (use List_mb_policies for names) refer to existing policies on the verifier. Leave empty to enroll without policy."}, masking.WrapTool(mask, toolHandler.EnrollAgentToVerifier))
+	mcp.AddTool(server, &mcp.Tool{Name: "Update_agent", Description: "Re-enrolls an agent with a new policy. Safely validates everything before unenrolling, then re-enrolls. Use this instead of manually calling Unenroll + Enroll."}, masking.WrapTool(mask, toolHandler.UpdateAgent))
+	mcp.AddTool(server, &mcp.Tool{Name: "Unenroll_agent_from_verifier", Description: "Unenrolls an agent from the verifier (NOT the registrar)"}, masking.WrapTool(mask, toolHandler.UnenrollAgentFromVerifier))
+	mcp.AddTool(server, &mcp.Tool{Name: "Stop_agent", Description: "Stop Verifier polling on an agent identified by its UUID, but does not remove the agent"}, masking.WrapTool(mask, toolHandler.StopAgent))
+	mcp.AddTool(server, &mcp.Tool{Name: "List_runtime_policies", Description: "Lists names of runtime policies already uploaded to the verifier. These are policies available for assigning to agents during enrollment."}, masking.WrapTool(mask, toolHandler.ListRuntimePolicies))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_runtime_policy", Description: "Gets the content of a specific runtime policy stored on the verifier by name. Returns the policy JSON including digests, excludes, and keyrings. Use List_runtime_policies first to see available names."}, masking.WrapTool(mask, toolHandler.GetRuntimePolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "Import_runtime_policy", Description: "Uploads a local runtime policy JSON file to the verifier. If the user has no policy file, ask whether they want to generate it from a local filesystem or a remote RPM repo. For local: 'sudo keylime-policy create runtime --rootfs / -o /tmp/runtime_policy.json'. For RPM repo: 'sudo keylime-policy create runtime --remote-rpm-repo <URL> -o /tmp/runtime_policy.json'. Then provide the output path to this tool."}, masking.WrapTool(mask, toolHandler.ImportRuntimePolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "Update_runtime_policy", Description: "Updates an existing runtime policy on the verifier. Can add or remove excludes and digests. Fetches the current policy, applies changes, and re-uploads. Requires at least one of add_excludes, remove_excludes, add_digests, or remove_digests."}, masking.WrapTool(mask, toolHandler.UpdateRuntimePolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "Delete_runtime_policy", Description: "Deletes a runtime policy from the verifier by name. Use List_runtime_policies first to see available names."}, masking.WrapTool(mask, toolHandler.DeleteRuntimePolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "List_mb_policies", Description: "Lists names of measured boot policies already uploaded to the verifier. These are policies available for assigning to agents during enrollment."}, masking.WrapTool(mask, toolHandler.ListMBPolicies))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_mb_policy", Description: "Gets the content of a specific measured boot policy stored on the verifier by name. Returns the policy JSON including boot event logs and expected PCR values. Use List_mb_policies first to see available names."}, masking.WrapTool(mask, toolHandler.GetMBPolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "Import_mb_policy", Description: "Uploads a local measured boot policy JSON file to the verifier. If the user has no policy file, tell them to generate one with: 'sudo keylime-policy create measured-boot -e /sys/kernel/security/tpm0/binary_bios_measurements -o /tmp/mb_policy.json'. If it fails with a SecureBoot error, add the -i flag to generate without SecureBoot validation. Then provide the output path to this tool."}, masking.WrapTool(mask, toolHandler.ImportMBPolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "Delete_mb_policy", Description: "Deletes a measured boot policy from the verifier by name. Use List_mb_policies first to see available names."}, masking.WrapTool(mask, toolHandler.DeleteMBPolicy))
+	mcp.AddTool(server, &mcp.Tool{Name: "Get_verifier_logs", Description: "Investigates attestation failures and retrieves Keylime Verifier logs from journalctl. Requires co-located verifier. Filter by agent_uuid and use filter parameter: 'attestation_failures' for file mismatches, invalid quotes and policy violations, 'errors' for error-level messages, 'all' for unfiltered output (default). Lines parameter controls log window (default 50, max 200)."}, masking.WrapTool(mask, toolHandler.InvestigateVerifierLogs))
 	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 		log.Fatal(err)
 	}
@@ -57,16 +59,17 @@ func loadConfig() keylime.Config {
 	certDir := getEnv("KEYLIME_CERT_DIR", "/var/lib/keylime/cv_ca")
 
 	return keylime.Config{
-		VerifierURL:   getEnv("KEYLIME_VERIFIER_URL", "https://localhost:8881"),
-		RegistrarURL:  getEnv("KEYLIME_REGISTRAR_URL", "https://localhost:8891"),
-		CertDir:       certDir,
-		TLSEnabled:    getEnv("KEYLIME_TLS_ENABLED", "true") == "true",
-		TLSServerName: getEnv("KEYLIME_TLS_SERVER_NAME", "localhost"),
-		APIVersion:    getEnv("KEYLIME_API_VERSION", "v2.5"),
-		ClientCert:    getEnv("KEYLIME_CLIENT_CERT", certDir+"/client-cert.crt"),
-		ClientKey:     getEnv("KEYLIME_CLIENT_KEY", certDir+"/client-private.pem"),
-		CAPath:        getEnv("KEYLIME_CA_CERT", certDir+"/cacert.crt"),
-		Port:          getEnv("PORT", "8080"),
+		VerifierURL:    getEnv("KEYLIME_VERIFIER_URL", "https://localhost:8881"),
+		RegistrarURL:   getEnv("KEYLIME_REGISTRAR_URL", "https://localhost:8891"),
+		CertDir:        certDir,
+		TLSEnabled:     getEnv("KEYLIME_TLS_ENABLED", "true") == "true",
+		TLSServerName:  getEnv("KEYLIME_TLS_SERVER_NAME", "localhost"),
+		APIVersion:     getEnv("KEYLIME_API_VERSION", "v2.5"),
+		ClientCert:     getEnv("KEYLIME_CLIENT_CERT", certDir+"/client-cert.crt"),
+		ClientKey:      getEnv("KEYLIME_CLIENT_KEY", certDir+"/client-private.pem"),
+		CAPath:         getEnv("KEYLIME_CA_CERT", certDir+"/cacert.crt"),
+		Port:           getEnv("PORT", "8080"),
+		MaskingEnabled: getEnv("MASKING_ENABLED", "true") == "true",
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,12 +2,15 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
 
+	"github.com/keylime/keylime-mcp/internal/masking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -34,6 +37,7 @@ type Config struct {
 type Agent struct {
 	config     Config
 	provider   LLMProvider
+	masker     *masking.Engine
 	mcpSession *mcp.ClientSession
 	mcpCmd     *exec.Cmd
 	tools      []*mcp.Tool
@@ -43,7 +47,7 @@ type Agent struct {
 	toolQueue []ToolRequest
 }
 
-func NewAgent(cfg Config, provider LLMProvider) *Agent {
+func NewAgent(cfg Config, provider LLMProvider, masker *masking.Engine) *Agent {
 	if cfg.MaxTokens == 0 {
 		cfg.MaxTokens = DefaultMaxTokens
 	}
@@ -57,6 +61,7 @@ func NewAgent(cfg Config, provider LLMProvider) *Agent {
 	return &Agent{
 		config:   cfg,
 		provider: provider,
+		masker:   masker,
 		messages: []Message{},
 	}
 }
@@ -67,6 +72,7 @@ func (a *Agent) Connect(ctx context.Context) error {
 		Version: mcpClientVersion,
 	}, nil)
 	cmd := exec.Command(a.config.ServerPath) // #nosec G204 -- ServerPath is from trusted config, not user input
+	cmd.Env = append(os.Environ(), "MASKING_ENABLED=false")
 	transport := &mcp.CommandTransport{Command: cmd}
 	session, err := client.Connect(ctx, transport, nil)
 	if err != nil {
@@ -111,6 +117,19 @@ func (a *Agent) callLLM(ctx context.Context, onMessage func(Message)) error {
 
 	messagesCopy := make([]Message, len(a.messages))
 	copy(messagesCopy, a.messages)
+
+	if a.masker != nil {
+		for i := range messagesCopy {
+			if messagesCopy[i].ToolResult != nil {
+				messagesCopy[i].ToolResult = &ToolResult{
+					ToolID:  messagesCopy[i].ToolResult.ToolID,
+					Output:  a.masker.Mask(messagesCopy[i].ToolResult.Output),
+					IsError: messagesCopy[i].ToolResult.IsError,
+				}
+			}
+		}
+	}
+
 	opts := ChatOptions{
 		Model:        a.config.Model,
 		MaxTokens:    a.config.MaxTokens,
@@ -144,19 +163,25 @@ func (a *Agent) callLLM(ctx context.Context, onMessage func(Message)) error {
 	a.mu.Unlock()
 
 	if msg.Text != "" {
-		onMessage(Message{Role: RoleAssistant, Text: msg.Text})
+		displayText := msg.Text
+		if a.masker != nil {
+			displayText = a.masker.Unmask(displayText)
+		}
+		onMessage(Message{Role: RoleAssistant, Text: displayText})
 	}
 	if firstTool != nil {
-		onMessage(Message{Role: RoleAssistant, ToolCalls: []ToolRequest{*firstTool}})
+		onMessage(Message{Role: RoleAssistant, ToolCalls: []ToolRequest{a.unmaskToolRequest(*firstTool)}})
 	}
 
 	return nil
 }
 
 func (a *Agent) ExecuteTool(ctx context.Context, toolRequest *ToolRequest, onMessage func(Message)) error {
+	unmasked := a.unmaskToolRequest(*toolRequest)
+
 	result, err := a.mcpSession.CallTool(ctx, &mcp.CallToolParams{
-		Name:      toolRequest.Name,
-		Arguments: toolRequest.Arguments,
+		Name:      unmasked.Name,
+		Arguments: unmasked.Arguments,
 	})
 
 	var resultText string
@@ -226,11 +251,30 @@ func (a *Agent) advanceToolQueue(ctx context.Context, onMessage func(Message)) e
 	a.mu.Unlock()
 
 	if nextTool != nil {
-		onMessage(Message{Role: RoleAssistant, ToolCalls: []ToolRequest{*nextTool}})
+		onMessage(Message{Role: RoleAssistant, ToolCalls: []ToolRequest{a.unmaskToolRequest(*nextTool)}})
 		return nil
 	}
 
 	return a.callLLM(ctx, onMessage)
+}
+
+func (a *Agent) unmaskToolRequest(tr ToolRequest) ToolRequest {
+	if a.masker == nil || !a.masker.Enabled() {
+		return tr
+	}
+	argsJSON, err := json.Marshal(tr.Arguments)
+	if err != nil {
+		return tr
+	}
+	unmasked := a.masker.Unmask(string(argsJSON))
+	if unmasked == string(argsJSON) {
+		return tr
+	}
+	var realArgs any
+	if err := json.Unmarshal([]byte(unmasked), &realArgs); err != nil {
+		return tr
+	}
+	return ToolRequest{ID: tr.ID, Name: tr.Name, Arguments: realArgs}
 }
 
 func extractTextContent(content []mcp.Content) string {

--- a/internal/keylime/types.go
+++ b/internal/keylime/types.go
@@ -45,11 +45,12 @@ type Config struct {
 	TLSEnabled    bool
 	TLSServerName string
 
-	APIVersion string
-	ClientCert string
-	ClientKey  string // #nosec G117 -- field name for cert key path, value is not hardcoded
-	CAPath     string
-	Port       string
+	APIVersion     string
+	ClientCert     string
+	ClientKey      string // #nosec G117 -- field name for cert key path, value is not hardcoded
+	CAPath         string
+	Port           string
+	MaskingEnabled bool
 }
 
 type Client struct {

--- a/internal/masking/aliasmap.go
+++ b/internal/masking/aliasmap.go
@@ -1,0 +1,42 @@
+package masking
+
+import (
+	"fmt"
+	"sync"
+)
+
+type AliasMap struct {
+	mu      sync.RWMutex
+	prefix  string
+	counter int
+	forward map[string]string
+	inverse map[string]string
+}
+
+func NewAliasMap(prefix string) *AliasMap {
+	return &AliasMap{
+		prefix:  prefix,
+		forward: make(map[string]string),
+		inverse: make(map[string]string),
+	}
+}
+
+func (m *AliasMap) GetOrCreate(real string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if alias, ok := m.forward[real]; ok {
+		return alias
+	}
+	m.counter++
+	alias := fmt.Sprintf("%s-%d", m.prefix, m.counter)
+	m.forward[real] = alias
+	m.inverse[alias] = real
+	return alias
+}
+
+func (m *AliasMap) Resolve(alias string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	real, ok := m.inverse[alias]
+	return real, ok
+}

--- a/internal/masking/engine.go
+++ b/internal/masking/engine.go
@@ -3,7 +3,6 @@ package masking
 import (
 	"net"
 	"regexp"
-	"strings"
 )
 
 var (
@@ -11,7 +10,7 @@ var (
 	ipv4RE   = regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
 	ipv6RE   = regexp.MustCompile(`[0-9a-fA-F]{0,4}(?::[0-9a-fA-F]{0,4}){2,7}`)
 	hashRE   = regexp.MustCompile(`\b[0-9a-fA-F]{128}\b|\b[0-9a-fA-F]{96}\b|\b[0-9a-fA-F]{64}\b|\b[0-9a-fA-F]{40}\b`)
-	tpmKeyRE = regexp.MustCompile(`"(aik_tpm|ek_tpm|ekcert|mtls_cert)"\s*:\s*"[^"]*"`)
+	tpmKeyRE = regexp.MustCompile(`("(?:aik_tpm|ek_tpm|ekcert|mtls_cert)"\s*:\s*")([^"]*)"`)
 	aliasRE  = regexp.MustCompile(`\b(AGENT|HOST|HASH|TPM)-\d+\b`)
 )
 
@@ -43,13 +42,9 @@ func (e *Engine) Mask(text string) string {
 	}
 
 	text = tpmKeyRE.ReplaceAllStringFunc(text, func(match string) string {
-		if before, value, ok := strings.Cut(match, `":"`); ok {
-			value = strings.TrimSuffix(value, `"`)
-			return before + `":"` + e.tpmKeys.GetOrCreate(value) + `"`
-		}
-		if before, value, ok := strings.Cut(match, `": "`); ok {
-			value = strings.TrimSuffix(value, `"`)
-			return before + `": "` + e.tpmKeys.GetOrCreate(value) + `"`
+		parts := tpmKeyRE.FindStringSubmatch(match)
+		if len(parts) == 3 {
+			return parts[1] + e.tpmKeys.GetOrCreate(parts[2]) + `"`
 		}
 		return match
 	})

--- a/internal/masking/engine.go
+++ b/internal/masking/engine.go
@@ -1,0 +1,91 @@
+package masking
+
+import (
+	"net"
+	"regexp"
+	"strings"
+)
+
+var (
+	uuidRE   = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	ipv4RE   = regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
+	ipv6RE   = regexp.MustCompile(`[0-9a-fA-F]{0,4}(?::[0-9a-fA-F]{0,4}){2,7}`)
+	hashRE   = regexp.MustCompile(`\b[0-9a-fA-F]{128}\b|\b[0-9a-fA-F]{96}\b|\b[0-9a-fA-F]{64}\b|\b[0-9a-fA-F]{40}\b`)
+	tpmKeyRE = regexp.MustCompile(`"(aik_tpm|ek_tpm|ekcert|mtls_cert)"\s*:\s*"[^"]*"`)
+	aliasRE  = regexp.MustCompile(`\b(AGENT|HOST|HASH|TPM)-\d+\b`)
+)
+
+type Engine struct {
+	enabled bool
+	agents  *AliasMap
+	hosts   *AliasMap
+	hashes  *AliasMap
+	tpmKeys *AliasMap
+}
+
+func NewEngine(enabled bool) *Engine {
+	return &Engine{
+		enabled: enabled,
+		agents:  NewAliasMap("AGENT"),
+		hosts:   NewAliasMap("HOST"),
+		hashes:  NewAliasMap("HASH"),
+		tpmKeys: NewAliasMap("TPM"),
+	}
+}
+
+func (e *Engine) Enabled() bool {
+	return e.enabled
+}
+
+func (e *Engine) Mask(text string) string {
+	if !e.enabled {
+		return text
+	}
+
+	text = tpmKeyRE.ReplaceAllStringFunc(text, func(match string) string {
+		if before, value, ok := strings.Cut(match, `":"`); ok {
+			value = strings.TrimSuffix(value, `"`)
+			return before + `":"` + e.tpmKeys.GetOrCreate(value) + `"`
+		}
+		if before, value, ok := strings.Cut(match, `": "`); ok {
+			value = strings.TrimSuffix(value, `"`)
+			return before + `": "` + e.tpmKeys.GetOrCreate(value) + `"`
+		}
+		return match
+	})
+
+	text = uuidRE.ReplaceAllStringFunc(text, func(match string) string {
+		return e.agents.GetOrCreate(match)
+	})
+
+	maskIP := func(match string) string {
+		if net.ParseIP(match) == nil {
+			return match
+		}
+		return e.hosts.GetOrCreate(match)
+	}
+	text = ipv4RE.ReplaceAllStringFunc(text, maskIP)
+	text = ipv6RE.ReplaceAllStringFunc(text, maskIP)
+
+	text = hashRE.ReplaceAllStringFunc(text, func(match string) string {
+		return e.hashes.GetOrCreate(match)
+	})
+
+	return text
+}
+
+func (e *Engine) Unmask(text string) string {
+	if !e.enabled {
+		return text
+	}
+
+	maps := []*AliasMap{e.agents, e.hosts, e.hashes, e.tpmKeys}
+	return aliasRE.ReplaceAllStringFunc(text, func(match string) string {
+		for _, m := range maps {
+			if real, ok := m.Resolve(match); ok {
+				return real
+			}
+		}
+		return match
+	})
+}

--- a/internal/masking/engine_test.go
+++ b/internal/masking/engine_test.go
@@ -100,6 +100,17 @@ func TestMaskTPMBlobs(t *testing.T) {
 	assert.Contains(t, masked, "HOST-1")
 }
 
+func TestMaskTPMRoundtrip(t *testing.T) {
+	e := NewEngine(true)
+
+	original := `{"aik_tpm":"base64-aik-data","ek_tpm":"base64-ek-data","ekcert":"base64-cert","mtls_cert":"base64-mtls"}`
+	masked := e.Mask(original)
+	assert.NotEqual(t, original, masked)
+
+	unmasked := e.Unmask(masked)
+	assert.Equal(t, original, unmasked)
+}
+
 func TestUnmask(t *testing.T) {
 	e := NewEngine(true)
 

--- a/internal/masking/engine_test.go
+++ b/internal/masking/engine_test.go
@@ -1,0 +1,345 @@
+package masking
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestMaskUUIDs(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"agents":["d432fbb3-d2f1-4a97-9ef7-75bd81c00000","a1b2c3d4-e5f6-7890-abcd-ef1234567890"]}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "d432fbb3-d2f1-4a97-9ef7-75bd81c00000")
+	assert.NotContains(t, masked, "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	assert.Contains(t, masked, "AGENT-1")
+	assert.Contains(t, masked, "AGENT-2")
+}
+
+func TestMaskUUIDDeterministic(t *testing.T) {
+	e := NewEngine(true)
+
+	uuid := "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+	text1 := `{"agent":"` + uuid + `"}`
+	text2 := `{"other":"` + uuid + `"}`
+
+	masked1 := e.Mask(text1)
+	masked2 := e.Mask(text2)
+
+	assert.Contains(t, masked1, "AGENT-1")
+	assert.Contains(t, masked2, "AGENT-1")
+}
+
+func TestMaskIPv4(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"ip":"192.168.1.100","verifier_ip":"10.0.0.5"}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "192.168.1.100")
+	assert.NotContains(t, masked, "10.0.0.5")
+	assert.Contains(t, masked, "HOST-1")
+	assert.Contains(t, masked, "HOST-2")
+}
+
+func TestMaskIPv4SkipsInvalid(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"version":"999.999.999.999"}`
+	masked := e.Mask(text)
+
+	assert.Equal(t, text, masked)
+}
+
+func TestMaskHashes(t *testing.T) {
+	e := NewEngine(true)
+
+	sha256 := testSHA256
+	sha1 := "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+	text := `{"digests":{"sha256":"` + sha256 + `","sha1":"` + sha1 + `"}}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, sha256)
+	assert.NotContains(t, masked, sha1)
+	assert.Contains(t, masked, "HASH-1")
+	assert.Contains(t, masked, "HASH-2")
+}
+
+func TestMaskHashEquivalence(t *testing.T) {
+	e := NewEngine(true)
+
+	hash := testSHA256
+	text := `{"allowlist":"` + hash + `","runtime":"` + hash + `"}`
+	masked := e.Mask(text)
+
+	count := strings.Count(masked, "HASH-1")
+	assert.Equal(t, 2, count)
+}
+
+func TestMaskTPMBlobs(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"aik_tpm":"long-aik-key-data","ek_tpm":"long-ek-key-data","ekcert":"cert-data","mtls_cert":"mtls-data","ip":"10.0.0.1"}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "long-aik-key-data")
+	assert.NotContains(t, masked, "long-ek-key-data")
+	assert.NotContains(t, masked, "cert-data")
+	assert.NotContains(t, masked, "mtls-data")
+	assert.Contains(t, masked, `"aik_tpm":"TPM-1"`)
+	assert.Contains(t, masked, `"ek_tpm":"TPM-2"`)
+	assert.Contains(t, masked, `"ekcert":"TPM-3"`)
+	assert.Contains(t, masked, `"mtls_cert":"TPM-4"`)
+	assert.Contains(t, masked, "HOST-1")
+}
+
+func TestUnmask(t *testing.T) {
+	e := NewEngine(true)
+
+	uuid := "d432fbb3-d2f1-4a97-9ef7-75bd81c00000"
+	ip := "192.168.1.100"
+	hash := testSHA256
+
+	original := `{"uuid":"` + uuid + `","ip":"` + ip + `","hash":"` + hash + `"}`
+	masked := e.Mask(original)
+
+	assert.Contains(t, masked, "AGENT-1")
+	assert.Contains(t, masked, "HOST-1")
+	assert.Contains(t, masked, "HASH-1")
+
+	unmasked := e.Unmask(masked)
+	assert.Contains(t, unmasked, uuid)
+	assert.Contains(t, unmasked, ip)
+	assert.Contains(t, unmasked, hash)
+}
+
+func TestUnmaskUnknownAlias(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"agent":"AGENT-99"}`
+	unmasked := e.Unmask(text)
+
+	assert.Equal(t, text, unmasked)
+}
+
+func TestDisabledEngine(t *testing.T) {
+	e := NewEngine(false)
+
+	text := `{"uuid":"d432fbb3-d2f1-4a97-9ef7-75bd81c00000","ip":"192.168.1.100"}`
+
+	assert.Equal(t, text, e.Mask(text))
+	assert.Equal(t, text, e.Unmask(text))
+	assert.False(t, e.Enabled())
+}
+
+func TestMaskAgentStatusPayload(t *testing.T) {
+	e := NewEngine(true)
+
+	payload := map[string]any{
+		"agent_uuid":                    "d432fbb3-d2f1-4a97-9ef7-75bd81c00000",
+		"operational_state":             3,
+		"operational_state_description": "Get Quote",
+		"attestation_count":             42,
+		"hash_algorithm":                "sha256",
+		"encryption_algorithm":          "rsa",
+		"signing_algorithm":             "rsassa",
+		"verifier_id":                   "default",
+		"verifier_address":              "127.0.0.1:8881",
+		"has_measured_boot":             false,
+		"has_runtime_policy":            true,
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	masked := e.Mask(string(data))
+
+	assert.NotContains(t, masked, "d432fbb3-d2f1-4a97-9ef7-75bd81c00000")
+	assert.NotContains(t, masked, "127.0.0.1")
+	assert.Contains(t, masked, "AGENT-1")
+	assert.Contains(t, masked, "HOST-1")
+
+	assert.Contains(t, masked, `"operational_state":3`)
+	assert.Contains(t, masked, `"attestation_count":42`)
+	assert.Contains(t, masked, `"hash_algorithm":"sha256"`)
+}
+
+func TestMaskRegistrarDetailsPayload(t *testing.T) {
+	e := NewEngine(true)
+
+	payload := map[string]any{
+		"code":   200,
+		"status": "Success",
+		"results": map[string]any{
+			"aik_tpm":   "test-aik-data-base64-encoded",
+			"ek_tpm":    "test-ek-data-base64-encoded",
+			"ekcert":    "test-ek-cert-pem",
+			"mtls_cert": "test-mtls-cert-pem",
+			"ip":        "192.168.1.100",
+			"port":      9002,
+			"regcount":  1,
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	masked := e.Mask(string(data))
+
+	assert.NotContains(t, masked, "test-aik-data-base64-encoded")
+	assert.NotContains(t, masked, "test-ek-data-base64-encoded")
+	assert.NotContains(t, masked, "test-ek-cert-pem")
+	assert.NotContains(t, masked, "test-mtls-cert-pem")
+	assert.NotContains(t, masked, "192.168.1.100")
+
+	assert.Contains(t, masked, `"aik_tpm":"TPM-1"`)
+	assert.Contains(t, masked, `"ek_tpm":"TPM-2"`)
+	assert.Contains(t, masked, `"ekcert":"TPM-3"`)
+	assert.Contains(t, masked, `"mtls_cert":"TPM-4"`)
+	assert.Contains(t, masked, "HOST-1")
+}
+
+func TestMaskMultipleAgentsPayload(t *testing.T) {
+	e := NewEngine(true)
+
+	payload := map[string]any{
+		"agents": []string{
+			"d432fbb3-d2f1-4a97-9ef7-75bd81c00000",
+			"a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+			"11111111-2222-3333-4444-555555555555",
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	masked := e.Mask(string(data))
+
+	assert.Contains(t, masked, "AGENT-1")
+	assert.Contains(t, masked, "AGENT-2")
+	assert.Contains(t, masked, "AGENT-3")
+
+	unmasked := e.Unmask(masked)
+	assert.Contains(t, unmasked, "d432fbb3-d2f1-4a97-9ef7-75bd81c00000")
+	assert.Contains(t, unmasked, "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	assert.Contains(t, unmasked, "11111111-2222-3333-4444-555555555555")
+}
+
+func TestMaskRoundtrip(t *testing.T) {
+	e := NewEngine(true)
+
+	original := `{"uuid":"d432fbb3-d2f1-4a97-9ef7-75bd81c00000","ip":"10.0.0.1","hash":"` + testSHA256 + `"}`
+
+	masked := e.Mask(original)
+	assert.NotEqual(t, original, masked)
+
+	unmasked := e.Unmask(masked)
+	assert.Equal(t, original, unmasked)
+}
+
+func TestMaskPreservesNonSensitiveData(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"operational_state":3,"hash_alg":"sha256","port":9002,"status":"Success","count":42}`
+	masked := e.Mask(text)
+
+	assert.Equal(t, text, masked)
+}
+
+func TestMaskErrorMessage(t *testing.T) {
+	e := NewEngine(true)
+
+	errMsg := "CRITICAL: agent d432fbb3-d2f1-4a97-9ef7-75bd81c00000 at 192.168.1.100 failed attestation"
+	masked := e.Mask(errMsg)
+
+	assert.NotContains(t, masked, "d432fbb3-d2f1-4a97-9ef7-75bd81c00000")
+	assert.NotContains(t, masked, "192.168.1.100")
+	assert.Contains(t, masked, "AGENT-1")
+	assert.Contains(t, masked, "HOST-1")
+	assert.Contains(t, masked, "CRITICAL")
+	assert.Contains(t, masked, "failed attestation")
+}
+
+func TestMaskIPv6Full(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"ip":"2001:0db8:85a3:0000:0000:8a2e:0370:7334"}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+	assert.Contains(t, masked, "HOST-1")
+}
+
+func TestMaskIPv6Compressed(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"ip":"fe80::1","other":"2001:db8::8a2e:370:7334"}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "fe80::1")
+	assert.NotContains(t, masked, "2001:db8::8a2e:370:7334")
+	assert.Contains(t, masked, "HOST-1")
+	assert.Contains(t, masked, "HOST-2")
+}
+
+func TestMaskIPv6Loopback(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"ip":"::1"}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "::1")
+	assert.Contains(t, masked, "HOST-1")
+}
+
+func TestMaskIPv6Roundtrip(t *testing.T) {
+	e := NewEngine(true)
+
+	original := `{"ip":"2001:db8::1"}`
+	masked := e.Mask(original)
+	unmasked := e.Unmask(masked)
+
+	assert.Equal(t, original, unmasked)
+}
+
+func TestMaskIPv6AndIPv4Together(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"ipv4":"192.168.1.1","ipv6":"fe80::1"}`
+	masked := e.Mask(text)
+
+	assert.NotContains(t, masked, "192.168.1.1")
+	assert.NotContains(t, masked, "fe80::1")
+	assert.Contains(t, masked, "HOST-1")
+	assert.Contains(t, masked, "HOST-2")
+}
+
+func TestMaskIPv6SkipsNonIP(t *testing.T) {
+	e := NewEngine(true)
+
+	text := `{"hash_alg":"sha256","status":"ok"}`
+	masked := e.Mask(text)
+
+	assert.Equal(t, text, masked)
+}
+
+func TestMaskIMALogLine(t *testing.T) {
+	e := NewEngine(true)
+
+	imaLine := `10 7a84eba7af1c3e3aff7af83e2d4b945a1b1cb3e0 ima-ng sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 /usr/bin/test`
+	masked := e.Mask(imaLine)
+
+	assert.NotContains(t, masked, "7a84eba7af1c3e3aff7af83e2d4b945a1b1cb3e0")
+	assert.NotContains(t, masked, testSHA256)
+	assert.Contains(t, masked, "HASH-")
+	assert.Contains(t, masked, "/usr/bin/test")
+	assert.Contains(t, masked, "ima-ng")
+	assert.Contains(t, masked, "sha256:")
+}

--- a/internal/masking/wrapper.go
+++ b/internal/masking/wrapper.go
@@ -1,0 +1,51 @@
+package masking
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func WrapTool[In, Out any](engine *Engine, handler mcp.ToolHandlerFor[In, Out]) mcp.ToolHandlerFor[In, Out] {
+	if !engine.Enabled() {
+		return handler
+	}
+
+	return func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, Out, error) {
+		var zero Out
+
+		inputJSON, err := json.Marshal(input)
+		if err != nil {
+			return nil, zero, err
+		}
+		unmasked := engine.Unmask(string(inputJSON))
+		if unmasked != string(inputJSON) {
+			if err := json.Unmarshal([]byte(unmasked), &input); err != nil {
+				return nil, zero, err
+			}
+		}
+
+		result, output, err := handler(ctx, req, input)
+
+		if err != nil {
+			return nil, zero, errors.New(engine.Mask(err.Error()))
+		}
+
+		outputJSON, err := json.Marshal(output)
+		if err != nil {
+			return result, output, nil
+		}
+		masked := engine.Mask(string(outputJSON))
+		if masked == "null" {
+			return result, output, nil
+		}
+		if result == nil {
+			result = &mcp.CallToolResult{}
+		}
+		result.Content = []mcp.Content{&mcp.TextContent{Text: masked}}
+		result.StructuredContent = json.RawMessage(masked)
+		return result, zero, nil
+	}
+}

--- a/internal/masking/wrapper.go
+++ b/internal/masking/wrapper.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func WrapTool[In, Out any](engine *Engine, handler mcp.ToolHandlerFor[In, Out]) mcp.ToolHandlerFor[In, Out] {
-	if !engine.Enabled() {
+	if engine == nil || !engine.Enabled() {
 		return handler
 	}
 
@@ -35,7 +36,7 @@ func WrapTool[In, Out any](engine *Engine, handler mcp.ToolHandlerFor[In, Out]) 
 
 		outputJSON, err := json.Marshal(output)
 		if err != nil {
-			return result, output, nil
+			return nil, zero, fmt.Errorf("failed to marshal output for masking: %w", err)
 		}
 		masked := engine.Mask(string(outputJSON))
 		if masked == "null" {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -324,7 +324,7 @@ func (h *ToolHandler) ReactivateAgent(ctx context.Context, req *mcp.CallToolRequ
 		return nil, nil, err
 	}
 	result, err := fetchAndDecode[keylime.ReactivateAgentOutput](
-		h.service.Verifier.Put(ctx, fmt.Sprintf("agents/%s/reactivate", input.AgentUUID), nil),
+		h.service.Verifier.Put(ctx, fmt.Sprintf("agents/%s/reactivate", input.AgentUUID), struct{}{}),
 	)
 	if err != nil {
 		return nil, nil, err
@@ -341,7 +341,7 @@ func (h *ToolHandler) StopAgent(ctx context.Context, req *mcp.CallToolRequest, i
 		return nil, nil, err
 	}
 	result, err := fetchAndDecode[keylime.StopAgentOutput](
-		h.service.Verifier.Put(ctx, fmt.Sprintf("agents/%s/stop", input.AgentUUID), nil),
+		h.service.Verifier.Put(ctx, fmt.Sprintf("agents/%s/stop", input.AgentUUID), struct{}{}),
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Replaces sensitive Keylime data (UUIDs, IPs, hashes, TPM keys/certs) with deterministic aliases (AGENT-1, HOST-1, HASH-1, TPM-1) before sending to LLM provider. Unmasks back on tool inputs and user-facing output. Enabled by default.

## Summary by Sourcery

Introduce a masking engine to obfuscate sensitive Keylime data when interacting with LLMs and MCP tools, while preserving the ability to transparently unmask data for actual tool execution and user-facing output.

New Features:
- Add a configurable masking engine that replaces UUIDs, IPs, hashes, and TPM-related fields with deterministic aliases for LLM-visible data.
- Integrate masking into the MCP server tool handlers and client agent so tool inputs/outputs and assistant messages are masked before reaching the LLM and unmasked when invoking tools.

Enhancements:
- Extend configuration to support enabling or disabling masking via environment variables on both server and client.
- Update agent and server wiring so masking behavior can be centrally controlled and disabled for the internal MCP server subprocess.
- Refine certificate setup in the Makefile to grant persistent read access via systemd-tmpfiles instead of one-off ACL changes.

Tests:
- Add comprehensive unit tests for the masking engine covering UUID, IP (IPv4/IPv6), hash, TPM blob, and log line masking and unmasking behavior, including determinism and round-tripping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic sensitive-data masking for LLM interactions (UUIDs, IPs, hashes, TPM data); toggle via new MASKING_ENABLED (true by default).
  * Tool I/O and assistant messages are masked/unmasked when masking is enabled.

* **Bug Fixes**
  * Tool calls now send an explicit empty request body where required.

* **Chores**
  * Certificate setup updated to create a persistent permission config and reflect “permanent read access” in help text.

* **Tests**
  * Added comprehensive tests covering masking/unmasking and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->