### PR TITLE
caching for anthropic claude and better code formatting

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -94,7 +95,7 @@ func loadConfig() config {
 		OllamaURL:      getEnv("OLLAMA_URL", "http://localhost:11434"),
 		OllamaModel:    os.Getenv("OLLAMA_MODEL"),
 		AnthropicKey:   strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")),
-		MaskingEnabled: getEnv("MASKING_ENABLED", "true") == "true",
+		MaskingEnabled: parseBool(getEnv("MASKING_ENABLED", "true")),
 	}
 }
 
@@ -103,6 +104,11 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func parseBool(s string) bool {
+	v, _ := strconv.ParseBool(s)
+	return v
 }
 
 func createProviders(cfg config) ([]agent.LLMProvider, agent.LLMProvider, string) {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -15,12 +15,14 @@ import (
 	"github.com/keylime/keylime-mcp/internal/web"
 )
 
-const (
-	defaultServerPath = "./server"
-	defaultPort       = "3000"
-	defaultOllamaURL  = "http://localhost:11434"
-	envFileLocation   = "./../.env"
-)
+type config struct {
+	ServerPath     string
+	Port           string
+	OllamaURL      string
+	OllamaModel    string
+	AnthropicKey   string
+	MaskingEnabled bool
+}
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -34,40 +36,26 @@ func main() {
 		cancel()
 	}()
 
-	if err := godotenv.Load(envFileLocation); err != nil {
-		log.Printf("Warning: .env file not loaded: %v", err)
-	}
+	cfg := loadConfig()
 
-	serverPath := os.Getenv("MCP_SERVER_PATH")
-	if serverPath == "" {
-		serverPath = defaultServerPath
-	}
-
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = defaultPort
-	}
-
-	if _, err := os.Stat(serverPath); os.IsNotExist(err) { // #nosec G703 -- serverPath from env/default, not user input
-		log.Printf("Warning: MCP server not found at %s", serverPath)
+	if _, err := os.Stat(cfg.ServerPath); os.IsNotExist(err) { // #nosec G703 -- serverPath from env/default, not user input
+		log.Printf("Warning: MCP server not found at %s", cfg.ServerPath)
 		log.Printf("Build the server first: go build -o bin/server cmd/server/main.go")
 		return
 	}
 
-	providers, initialProvider, initialModel := createProviders()
+	providers, initialProvider, initialModel := createProviders(cfg)
 
-	cfg := agent.Config{ServerPath: serverPath, Model: initialModel}
-	if cfg.Model == "" {
+	agentCfg := agent.Config{ServerPath: cfg.ServerPath, Model: initialModel}
+	if agentCfg.Model == "" {
 		if models, err := initialProvider.ListModels(ctx); err == nil && len(models) > 0 {
-			cfg.Model = models[0].ID
-			log.Printf("Auto-selected model: %s", cfg.Model)
+			agentCfg.Model = models[0].ID
+			log.Printf("Auto-selected model: %s", agentCfg.Model)
 		}
 	}
 
-	maskingEnabled := os.Getenv("MASKING_ENABLED") != "false"
-	masker := masking.NewEngine(maskingEnabled)
-
-	agentInstance := agent.NewAgent(cfg, initialProvider, masker)
+	masker := masking.NewEngine(cfg.MaskingEnabled)
+	agentInstance := agent.NewAgent(agentCfg, initialProvider, masker)
 
 	if err := agentInstance.Connect(ctx); err != nil {
 		log.Printf("Failed to connect to MCP server: %v", err)
@@ -87,7 +75,7 @@ func main() {
 		return
 	}
 
-	addr := fmt.Sprintf(":%s", port)
+	addr := fmt.Sprintf(":%s", cfg.Port)
 	log.Printf("Starting Keylime MCP Agent at http://localhost%s", addr)
 
 	if err := srv.Start(addr); err != nil {
@@ -96,29 +84,42 @@ func main() {
 	}
 }
 
-func createProviders() ([]agent.LLMProvider, agent.LLMProvider, string) {
-	ollamaURL := os.Getenv("OLLAMA_URL")
-	ollamaModel := os.Getenv("OLLAMA_MODEL")
-	apiKey := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
-
-	if ollamaURL == "" {
-		ollamaURL = defaultOllamaURL
+func loadConfig() config {
+	if err := godotenv.Load("./../.env"); err != nil {
+		log.Printf("Warning: .env file not loaded: %v", err)
 	}
+	return config{
+		ServerPath:     getEnv("MCP_SERVER_PATH", "./server"),
+		Port:           getEnv("PORT", "3000"),
+		OllamaURL:      getEnv("OLLAMA_URL", "http://localhost:11434"),
+		OllamaModel:    os.Getenv("OLLAMA_MODEL"),
+		AnthropicKey:   strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")),
+		MaskingEnabled: getEnv("MASKING_ENABLED", "true") == "true",
+	}
+}
 
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func createProviders(cfg config) ([]agent.LLMProvider, agent.LLMProvider, string) {
 	var providers []agent.LLMProvider
 
 	var claudeProvider *agent.AnthropicProvider
-	if apiKey != "" {
-		claudeProvider = agent.NewClaudeProvider(apiKey)
+	if cfg.AnthropicKey != "" {
+		claudeProvider = agent.NewClaudeProvider(cfg.AnthropicKey)
 		providers = append(providers, claudeProvider)
 	}
 
-	ollamaProvider := agent.NewOllamaProvider(ollamaURL)
+	ollamaProvider := agent.NewOllamaProvider(cfg.OllamaURL)
 	providers = append(providers, ollamaProvider)
 
-	if ollamaModel != "" || os.Getenv("OLLAMA_URL") != "" {
-		log.Printf("Using Ollama provider at %s", ollamaURL)
-		return providers, ollamaProvider, ollamaModel
+	if cfg.OllamaModel != "" || os.Getenv("OLLAMA_URL") != "" {
+		log.Printf("Using Ollama provider at %s", cfg.OllamaURL)
+		return providers, ollamaProvider, cfg.OllamaModel
 	}
 
 	if claudeProvider == nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/joho/godotenv"
 	"github.com/keylime/keylime-mcp/internal/keylime"
@@ -62,14 +63,14 @@ func loadConfig() keylime.Config {
 		VerifierURL:    getEnv("KEYLIME_VERIFIER_URL", "https://localhost:8881"),
 		RegistrarURL:   getEnv("KEYLIME_REGISTRAR_URL", "https://localhost:8891"),
 		CertDir:        certDir,
-		TLSEnabled:     getEnv("KEYLIME_TLS_ENABLED", "true") == "true",
+		TLSEnabled:     parseBool(getEnv("KEYLIME_TLS_ENABLED", "true")),
 		TLSServerName:  getEnv("KEYLIME_TLS_SERVER_NAME", "localhost"),
 		APIVersion:     getEnv("KEYLIME_API_VERSION", "v2.5"),
 		ClientCert:     getEnv("KEYLIME_CLIENT_CERT", certDir+"/client-cert.crt"),
 		ClientKey:      getEnv("KEYLIME_CLIENT_KEY", certDir+"/client-private.pem"),
 		CAPath:         getEnv("KEYLIME_CA_CERT", certDir+"/cacert.crt"),
 		Port:           getEnv("PORT", "8080"),
-		MaskingEnabled: getEnv("MASKING_ENABLED", "true") == "true",
+		MaskingEnabled: parseBool(getEnv("MASKING_ENABLED", "true")),
 	}
 }
 
@@ -78,4 +79,9 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+func parseBool(s string) bool {
+	v, _ := strconv.ParseBool(s)
+	return v
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -18,7 +18,7 @@ const (
 	mcpClientName    = "mcp-client"
 	mcpClientVersion = "v1.0.0"
 
-	DefaultMaxTokens = 2048
+	DefaultMaxTokens    = 2048
 	DefaultSystemPrompt = `You are a Keylime infrastructure assistant with access to tools. You help users manage and monitor Keylime agents.
 
 When users request information or actions, call the appropriate tool directly. You can call tools in sequence to complete multi-step tasks. After receiving tool results, summarize them for the user. If a tool returns an error, explain the issue and suggest a resolution.`

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -19,8 +19,6 @@ const (
 	mcpClientVersion = "v1.0.0"
 
 	DefaultMaxTokens = 2048
-	DefaultMaxTurns  = 5
-
 	DefaultSystemPrompt = `You are a Keylime infrastructure assistant with access to tools. You help users manage and monitor Keylime agents.
 
 When users request information or actions, call the appropriate tool directly. You can call tools in sequence to complete multi-step tasks. After receiving tool results, summarize them for the user. If a tool returns an error, explain the issue and suggest a resolution.`
@@ -30,7 +28,6 @@ type Config struct {
 	ServerPath   string
 	Model        string
 	MaxTokens    int64
-	MaxTurns     int
 	SystemPrompt string
 }
 
@@ -50,9 +47,6 @@ type Agent struct {
 func NewAgent(cfg Config, provider LLMProvider, masker *masking.Engine) *Agent {
 	if cfg.MaxTokens == 0 {
 		cfg.MaxTokens = DefaultMaxTokens
-	}
-	if cfg.MaxTurns == 0 {
-		cfg.MaxTurns = DefaultMaxTurns
 	}
 	if cfg.SystemPrompt == "" {
 		cfg.SystemPrompt = DefaultSystemPrompt

--- a/internal/agent/provider_anthropic.go
+++ b/internal/agent/provider_anthropic.go
@@ -23,7 +23,7 @@ func (b *anthropicBase) Chat(ctx context.Context, opts ChatOptions) (*LLMRespons
 	response, err := b.client.Messages.New(ctx, anthropic.MessageNewParams{
 		Model:     anthropic.Model(opts.Model),
 		MaxTokens: opts.MaxTokens,
-		System:    []anthropic.TextBlockParam{{Type: "text", Text: opts.SystemPrompt}},
+		System:    []anthropic.TextBlockParam{{Type: "text", Text: opts.SystemPrompt, CacheControl: anthropic.NewCacheControlEphemeralParam()}},
 		Messages:  messages,
 		Tools:     tools,
 	})
@@ -112,6 +112,9 @@ func convertToolsToAnthropic(tools []*mcp.Tool) []anthropic.ToolUnionParam {
 	result := make([]anthropic.ToolUnionParam, 0, len(tools))
 	for _, tool := range tools {
 		result = append(result, convertMCPToolToAnthropic(tool))
+	}
+	if len(result) > 0 {
+		result[len(result)-1].OfTool.CacheControl = anthropic.NewCacheControlEphemeralParam()
 	}
 	return result
 }

--- a/internal/keylime/types.go
+++ b/internal/keylime/types.go
@@ -257,6 +257,14 @@ type GetVerifierEnrolledAgentsOutput struct {
 	Agents []string `json:"agents"`
 }
 
+type VerifierEnrolledAgentsResponse struct {
+	Code    int    `json:"code"`
+	Status  string `json:"status"`
+	Results struct {
+		UUIDs [][]string `json:"uuids"`
+	} `json:"results"`
+}
+
 type ListRuntimePoliciesInput struct{}
 
 type ListRuntimePoliciesOutput struct {

--- a/internal/mcptools/tools.go
+++ b/internal/mcptools/tools.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"log"
 	"os/exec"
 	"strings"
 	"sync"
@@ -44,27 +42,9 @@ func (h *ToolHandler) GetVerifierEnrolledAgents(ctx context.Context, req *mcp.Ca
 	any,
 	error,
 ) {
-	resp, err := h.service.Verifier.Get(ctx, "agents/")
+	parsed, err := fetchAndDecode[keylime.VerifierEnrolledAgentsResponse](h.service.Verifier.Get(ctx, "agents/"))
 	if err != nil {
-		log.Printf("Error fetching enrolled agents: %v", err)
 		return nil, nil, err
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, keylime.ExtractAPIError(resp)
-	}
-
-	var parsed struct {
-		Results struct {
-			UUIDs [][]string `json:"uuids"`
-		} `json:"results"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
-		return nil, nil, fmt.Errorf("failed to decode verifier response: %w", err)
 	}
 
 	var uuids []string
@@ -277,22 +257,14 @@ func (h *ToolHandler) UpdateAgent(ctx context.Context, req *mcp.CallToolRequest,
 		return nil, nil, err
 	}
 
-	if err := deleteAndCheck(h.service.Verifier.Delete(ctx, fmt.Sprintf("agents/%s", input.AgentUUID))); err != nil {
+	if err := checkResponse(h.service.Verifier.Delete(ctx, fmt.Sprintf("agents/%s", input.AgentUUID))); err != nil {
 		return nil, nil, fmt.Errorf("failed to unenroll agent: %w", err)
 	}
 
-	resp, err := h.service.Verifier.Post(ctx, fmt.Sprintf("agents/%s", input.AgentUUID), body)
-	if err != nil {
+	if _, err := fetchAndDecode[keylime.EnrollAgentToVerifierOutput](
+		h.service.Verifier.Post(ctx, fmt.Sprintf("agents/%s", input.AgentUUID), body),
+	); err != nil {
 		return nil, nil, fmt.Errorf("CRITICAL: agent was unenrolled but re-enrollment failed: %w — manually re-enroll agent %s", err, input.AgentUUID)
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	var enrollResp keylime.EnrollAgentToVerifierOutput
-	if err := json.NewDecoder(resp.Body).Decode(&enrollResp); err != nil {
-		return nil, nil, fmt.Errorf("CRITICAL: agent was unenrolled but response decode failed: %w — verify agent %s status", err, input.AgentUUID)
 	}
 
 	return nil, keylime.UpdateAgentOutput{AgentUUID: input.AgentUUID, Status: "updated"}, nil
@@ -396,19 +368,8 @@ func (h *ToolHandler) ImportRuntimePolicy(ctx context.Context, req *mcp.CallTool
 		"runtime_policy": base64.StdEncoding.EncodeToString(data),
 	}
 
-	endpoint := fmt.Sprintf("allowlists/%s", input.Name)
-	resp, err := h.service.Verifier.Post(ctx, endpoint, body)
-	if err != nil {
-		log.Printf("Error importing runtime policy: %v", err)
+	if err := checkResponse(h.service.Verifier.Post(ctx, fmt.Sprintf("allowlists/%s", input.Name), body)); err != nil {
 		return nil, nil, err
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, keylime.ExtractAPIError(resp)
 	}
 
 	return nil, keylime.ImportRuntimePolicyOutput{Name: input.Name, Status: "imported"}, nil
@@ -427,23 +388,11 @@ func (h *ToolHandler) UpdateRuntimePolicy(ctx context.Context, req *mcp.CallTool
 		return nil, nil, fmt.Errorf("at least one of add_excludes, add_digests, remove_excludes or remove_digests is required")
 	}
 
-	// Fetch existing policy
-	getResp, err := h.service.Verifier.Get(ctx, fmt.Sprintf("allowlists/%s", input.PolicyName))
+	policyData, err := fetchAndDecode[keylime.GetRuntimePolicyOutput](
+		h.service.Verifier.Get(ctx, fmt.Sprintf("allowlists/%s", input.PolicyName)),
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch policy %q: %w", input.PolicyName, err)
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, getResp.Body)
-		_ = getResp.Body.Close()
-	}()
-
-	if getResp.StatusCode < 200 || getResp.StatusCode >= 300 {
-		return nil, nil, keylime.ExtractAPIError(getResp)
-	}
-
-	var policyData keylime.GetRuntimePolicyOutput
-	if err := json.NewDecoder(getResp.Body).Decode(&policyData); err != nil {
-		return nil, nil, fmt.Errorf("failed to decode policy %q: %w", input.PolicyName, err)
 	}
 	var policy map[string]any
 	policyStr := policyData.Results.RuntimePolicy
@@ -530,17 +479,8 @@ func (h *ToolHandler) UpdateRuntimePolicy(ctx context.Context, req *mcp.CallTool
 		"runtime_policy": base64.StdEncoding.EncodeToString(policyJSON),
 	}
 
-	reuploadResp, err := h.service.Verifier.Put(ctx, fmt.Sprintf("allowlists/%s", input.PolicyName), body)
-	if err != nil {
+	if err := checkResponse(h.service.Verifier.Put(ctx, fmt.Sprintf("allowlists/%s", input.PolicyName), body)); err != nil {
 		return nil, nil, fmt.Errorf("failed to update policy: %w", err)
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, reuploadResp.Body)
-		_ = reuploadResp.Body.Close()
-	}()
-
-	if reuploadResp.StatusCode < 200 || reuploadResp.StatusCode >= 300 {
-		return nil, nil, keylime.ExtractAPIError(reuploadResp)
 	}
 
 	return nil, keylime.UpdateRuntimePolicyOutput{PolicyName: input.PolicyName, Status: "updated"}, nil
@@ -554,7 +494,7 @@ func (h *ToolHandler) DeleteRuntimePolicy(ctx context.Context, req *mcp.CallTool
 	if err := validatePolicyName(input.PolicyName); err != nil {
 		return nil, nil, err
 	}
-	if err := deleteAndCheck(h.service.Verifier.Delete(ctx, fmt.Sprintf("allowlists/%s", input.PolicyName))); err != nil {
+	if err := checkResponse(h.service.Verifier.Delete(ctx, fmt.Sprintf("allowlists/%s", input.PolicyName))); err != nil {
 		return nil, nil, err
 	}
 	return nil, keylime.DeletePolicyOutput{PolicyName: input.PolicyName, Status: "deleted"}, nil
@@ -607,19 +547,8 @@ func (h *ToolHandler) ImportMBPolicy(ctx context.Context, req *mcp.CallToolReque
 		"mb_policy": string(data),
 	}
 
-	endpoint := fmt.Sprintf("mbpolicies/%s", input.Name)
-	resp, err := h.service.Verifier.Post(ctx, endpoint, body)
-	if err != nil {
-		log.Printf("Error importing measured boot policy: %v", err)
+	if err := checkResponse(h.service.Verifier.Post(ctx, fmt.Sprintf("mbpolicies/%s", input.Name), body)); err != nil {
 		return nil, nil, err
-	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, nil, keylime.ExtractAPIError(resp)
 	}
 
 	return nil, keylime.ImportMBPolicyOutput{Name: input.Name, Status: "imported"}, nil
@@ -633,7 +562,7 @@ func (h *ToolHandler) DeleteMBPolicy(ctx context.Context, req *mcp.CallToolReque
 	if err := validatePolicyName(input.PolicyName); err != nil {
 		return nil, nil, err
 	}
-	if err := deleteAndCheck(h.service.Verifier.Delete(ctx, fmt.Sprintf("mbpolicies/%s", input.PolicyName))); err != nil {
+	if err := checkResponse(h.service.Verifier.Delete(ctx, fmt.Sprintf("mbpolicies/%s", input.PolicyName))); err != nil {
 		return nil, nil, err
 	}
 	return nil, keylime.DeletePolicyOutput{PolicyName: input.PolicyName, Status: "deleted"}, nil

--- a/internal/mcptools/utils.go
+++ b/internal/mcptools/utils.go
@@ -35,8 +35,8 @@ func fetchAndDecode[T any](resp *http.Response, err error) (T, error) {
 	return result, nil
 }
 
-// deleteAndCheck verifies a DELETE request returned a success code.
-func deleteAndCheck(resp *http.Response, err error) error {
+// checkResponse verifies an HTTP request succeeded and discards the body.
+func checkResponse(resp *http.Response, err error) error {
 	if err != nil {
 		return err
 	}

--- a/internal/mcptools/utils_test.go
+++ b/internal/mcptools/utils_test.go
@@ -344,17 +344,17 @@ func TestFetchAndDecode(t *testing.T) {
 	})
 }
 
-func TestDeleteAndCheck(t *testing.T) {
+func TestCheckResponse(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		resp := &http.Response{
 			StatusCode: 200,
 			Body:       io.NopCloser(strings.NewReader("")),
 		}
-		assert.NoError(t, deleteAndCheck(resp, nil))
+		assert.NoError(t, checkResponse(resp, nil))
 	})
 
 	t.Run("http error", func(t *testing.T) {
-		err := deleteAndCheck(nil, fmt.Errorf("connection refused"))
+		err := checkResponse(nil, fmt.Errorf("connection refused"))
 		assert.ErrorContains(t, err, "connection refused")
 	})
 
@@ -363,7 +363,7 @@ func TestDeleteAndCheck(t *testing.T) {
 			StatusCode: 404,
 			Body:       io.NopCloser(strings.NewReader(`{"status":"not found"}`)),
 		}
-		err := deleteAndCheck(resp, nil)
+		err := checkResponse(resp, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "404")
 	})


### PR DESCRIPTION
## Summary by Sourcery

Add ephemeral cache control to Anthropic Claude chat requests to enable caching of system prompts and tools.

Enhancements:
- Configure Anthropic system prompt blocks with ephemeral cache control metadata.
- Apply ephemeral cache control to the last converted MCP tool when building Anthropic tool parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * System prompts and the last tool output are now treated as ephemeral to reduce latency and stale results.
* **New Features**
  * Added support to surface enrolled verifier agent lists more reliably.
* **Reliability**
  * HTTP handling for verifier and policy operations has been centralized to reduce failures.
  * Client startup configuration is consolidated for more consistent provider selection.
* **Behavior Change**
  * The agent no longer supports a configurable "max turns" setting.
* **Tests**
  * Tests updated to validate the new HTTP response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->